### PR TITLE
Fix issue with incorrect handling of the division operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ function initializeURLAsync(req, params, cb) {
     var parsonContent = '<script>\n';
     var initial = query.initial || 'No code given.';
 
-    initial = initial.replace(/\/n/g, '\\n');
     params.headContent += nj.render('head_simple.html', {'initial': initial, 'name': query.name });
     cb();
 }


### PR DESCRIPTION
https://github.com/acos-server/acos-jsparsons-generator/issues/1

There was a bug when previewing exercises encoded in the URL directly. The division operator got broken (vanished from the displayed code) if it was succeeded by the character n.

The removed regexp replace line targeted the division operator
followed by something started by the character n. It was probably
supposed to deal with line ends \n, but everything works fine
without it. The jsparsons-generator already handles the encoding
of line ends.